### PR TITLE
Add simple English/Korean localization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,17 @@
-import React from "react";
-import { Routes, Route } from "react-router-dom";
-import MainPage from "./pages/MainPage";
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import MainPage from './pages/MainPage';
+import { useLanguage } from './i18n';
 
 const App: React.FC = () => {
+  const { language, toggleLanguage } = useLanguage();
   return (
     <div>
+      <button onClick={toggleLanguage} style={{ position: 'absolute', top: 10, right: 10 }}>
+        {language === 'ko' ? 'English' : '한국어'}
+      </button>
       <Routes>
-        <Route path="*" element={<MainPage/>}/>
+        <Route path="*" element={<MainPage />} />
       </Routes>
     </div>
   );

--- a/src/components/accountModal.tsx
+++ b/src/components/accountModal.tsx
@@ -1,4 +1,5 @@
 import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { useTranslation } from '../i18n';
 
 
 interface AccountModalProps {
@@ -9,6 +10,8 @@ interface AccountModalProps {
 }
 
 const AccountModal: React.FC<AccountModalProps> = ({clickedAccountData, setClickedAccountData, copiedAccount, setCopiedAccount}) => {
+
+    const t = useTranslation();
 
     const delay = (ms: number) =>
         new Promise(resolve => setTimeout(resolve, ms));
@@ -36,29 +39,30 @@ const AccountModal: React.FC<AccountModalProps> = ({clickedAccountData, setClick
             {clickedAccountData.map((item, index) => (
                 <div key={index} className="account-info-each">
                     <div className="each-header">
-                        <div className="each-title">{item.title}</div>
+                        <div className="each-title">{t(item.title)}</div>
                     </div>
                     <hr className="each-line"></hr>
                     <div className="each-body">
                         <p className="each-account-text">
-                            {item.bank_name} (예금주 : {item.account_owner}) <br/>
+                            {item.bank_name} ({t('depositor')} : {item.account_owner}) <br/>
                             {item.account_number}
                         </p>
                         <CopyToClipboard
                         text={item.account_number}
                         onCopy={() => copyAccountNumber(item.account_number)}
                         >
-                            <div className="each-copy-btn" 
-                            >복사하기</div>
+                            <div className="each-copy-btn">
+                            {t('copy')}
+                            </div>
                         </CopyToClipboard>
                         
                     </div>
-                    { copiedAccount === item.account_number && <div className="copy-success">복사되었습니다.</div> }
+                    { copiedAccount === item.account_number && <div className="copy-success">{t('copied')}</div> }
                     
                     
                 </div>
             ))}
-            <div className="account-popup-close dismiss" onClick={accountClick}>닫기</div>
+            <div className="account-popup-close dismiss" onClick={accountClick}>{t('close')}</div>
         </div>
     </div>
     </>

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -1,0 +1,84 @@
+import React, { createContext, useContext, useState } from 'react';
+
+export type Language = 'en' | 'ko';
+
+interface Context {
+  language: Language;
+  toggleLanguage: () => void;
+}
+
+const LanguageContext = createContext<Context>({
+  language: 'ko',
+  toggleLanguage: () => {},
+});
+
+export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [language, setLanguage] = useState<Language>('ko');
+  const toggleLanguage = () => setLanguage(l => (l === 'ko' ? 'en' : 'ko'));
+  return (
+    <LanguageContext.Provider value={{ language, toggleLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => useContext(LanguageContext);
+
+const translations: Record<Language, Record<string, string>> = {
+  ko: {
+    invitationHeading: '결혼식에 초대합니다',
+    invitationIntro: '저희 두 사람이 사랑과 믿음으로 한 가정을 이루게 되었습니다. 바쁘시더라도 부디 오셔서 저희의 앞날을 축복해 주시고 격려해 주시면 감사하겠습니다.',
+    groomParents: '최진태・한미현의 차남 최연준',
+    brideParents: '고형균・박명선의 차녀 고은경',
+    dateLocation: '2025. 11. 09 일요일 오전 11시<br/>수원 노보텔',
+    locationName: '수원 노보텔',
+    locationAddress: '경기 수원시 팔달구 덕영대로 90<br/>2층 메인 홀<br/>Tel. 031-547-6600',
+    publicTransport: '대중교통',
+    transport1: '2호선 서울대입구역 3번 출구 → 5511,5513 버스 → 제2공학관(종점) 하차',
+    transport2: '2호선 낙성대역 4번 출구 → 관악02 마을버스 → 제2공학관(종점) 하차',
+    transport3: '신림선 관악산역 1번 출구 → 5511,5516 버스 → 제2공학관(종점) 하차',
+    byCar: '자가용',
+    carText: '네비게이션 이용 시 “이라운지 서울대점”을 입력하세요. (주차 2시간 무료)',
+    congratulate: '마음 전하실 곳',
+    groomAccount: '신랑측 계좌번호',
+    brideAccount: '신부측 계좌번호',
+    copy: '복사하기',
+    copied: '복사되었습니다.',
+    close: '닫기',
+    depositor: '예금주',
+    '신랑 계좌': '신랑 계좌',
+    '신부 계좌': '신부 계좌',
+    '혼주 계좌': '혼주 계좌',
+  },
+  en: {
+    invitationHeading: "You're Invited to Our Wedding",
+    invitationIntro: 'We are joining together in love and faith. We would be honored if you come celebrate and bless our future.',
+    groomParents: "Choi Jin Tae & Han Mi Hyun's son Yeon Jun",
+    brideParents: "Ko Hyeong Gyun & Park Myung Sun's daughter Eun Kyung",
+    dateLocation: 'Nov 9, 2025 (Sun) 11:00 AM<br/>Suwon Novotel',
+    locationName: 'Suwon Novotel',
+    locationAddress: '90 Deogyeong-daero, Paldal-gu, Suwon-si<br/>2F Main Hall<br/>Tel. 031-547-6600',
+    publicTransport: 'Public Transport',
+    transport1: 'Line 2 Seoul Nat\'l Univ. Entrance Exit 3 → Bus 5511 or 5513 → Engineering Building 2 (last stop)',
+    transport2: 'Line 2 Nakseongdae Exit 4 → Gwanak02 bus → Engineering Building 2 (last stop)',
+    transport3: 'Sillim Line Gwanaksan Station Exit 1 → Bus 5511 or 5516 → Engineering Building 2 (last stop)',
+    byCar: 'By Car',
+    carText: "Enter 'ELounge Seoul Nat\'l Univ' in your navigation. (2 hours free parking)",
+    congratulate: 'Where to send congratulations',
+    groomAccount: "Groom's Account",
+    brideAccount: "Bride's Account",
+    copy: 'Copy',
+    copied: 'Copied',
+    close: 'Close',
+    depositor: 'Account Holder',
+    '신랑 계좌': "Groom's account",
+    '신부 계좌': "Bride's account",
+    '혼주 계좌': "Parents' account",
+  },
+};
+
+export const useTranslation = () => {
+  const { language } = useLanguage();
+  return (key: string) => translations[language][key] || key;
+};
+

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,14 +3,17 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import { BrowserRouter } from 'react-router-dom';
+import { LanguageProvider } from './i18n';
 import reportWebVitals from './reportWebVitals';
 import { sendToVercelAnalytics } from './vitals';
 
 ReactDOM.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <LanguageProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </LanguageProvider>
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -9,6 +9,7 @@ import { Container as MapDiv, NaverMap, Marker, useNavermaps} from 'react-naver-
 import '../App.css';
 import ImageModal from '../components/imageModal';
 import AccountModal from '../components/accountModal';
+import { useTranslation } from '../i18n';
 
 const Bride: React.FC = () => {
   // state for image modal
@@ -17,6 +18,8 @@ const Bride: React.FC = () => {
   // state for account modal
   const [ clickedAccountData, setClickedAccountData ] = useState<any>(null);
   const [ copiedAccount, setCopiedAccount ] = useState<string | null>(null);
+
+  const t = useTranslation();
 
   const navermaps = useNavermaps()
 
@@ -75,27 +78,23 @@ const Bride: React.FC = () => {
                 <img src={mainImage} className='main-image' alt='t1'></img>
               </div>
               <div className='mainsection-text'>
-                <div className='mainsection-text-1'>결혼식에 초대합니다</div>
+                <div className='mainsection-text-1'>{t('invitationHeading')}</div>
                 <div className='mainsection-text-2'>
                   최연준 <span className='text2-inner'> & </span> 고은경
                 </div>
-                <div className='mainsection-text-3'>2025. 11. 09 일요일 오전 11시<br/>수원 노보텔</div>
+                <div className='mainsection-text-3' dangerouslySetInnerHTML={{ __html: t('dateLocation') }} />
               </div>
             </div>
             <div className='invitation-section'>
               <div className='invitation-section-text1'>INVITATION</div>
               <div className='invitation-section-text2'>
-                    저희 두 사람이 사랑과 믿음으로<br/>
-                    한 가정을 이루게 되었습니다.<br/>
-                    바쁘시더라도 부디 오셔서<br/>
-                    저희의 앞날을 축복해 주시고<br/>
-                    격려해 주시면 감사하겠습니다.
+                {t('invitationIntro')}
               </div>
               <div className='invitation-section-text3'>
-                최진태・한미현<span className='text3-inner'>의 차남</span> 최연준
+                {t('groomParents')}
               </div>
               <div className='invitation-section-text3'>
-                고형균・박명선<span className='text3-inner'>의 차녀</span> 고은경
+                {t('brideParents')}
               </div>
             </div>
             <div className='gallery-section'>
@@ -145,35 +144,31 @@ const Bride: React.FC = () => {
               </MapDiv>
             </div>
             <div className='location-info-section'>
-                <div className='location-info-section-text1'>수원 노보텔</div>
-                <div className='location-info-section-text2'>
-                    경기 수원시 팔달구 덕영대로 90<br/>
-                    2층 메인 홀<br/>
-                    Tel. 031-547-6600
-                </div>
+                <div className='location-info-section-text1'>{t('locationName')}</div>
+                <div className='location-info-section-text2' dangerouslySetInnerHTML={{ __html: t('locationAddress') }} />
             </div>
             <div className='location-how-publictrans-section'>
-              <div className='location-how-publictrans-section-text1'>대중교통</div>
+              <div className='location-how-publictrans-section-text1'>{t('publicTransport')}</div>
               <ol className='location-how-publictrans-section-list'>
-                <li>2호선 서울대입구역 3번 출구 → 5511,5513 버스 → 제2공학관(종점) 하차</li>
-                <li>2호선 낙성대역 4번 출구 → 관악02 마을버스 → 제2공학관(종점) 하차</li>
-                <li>신림선 관악산역 1번 출구 → 5511,5516 버스 → 제2공학관(종점) 하차</li>
+                <li>{t('transport1')}</li>
+                <li>{t('transport2')}</li>
+                <li>{t('transport3')}</li>
               </ol>
             </div>
             <div className='location-how2-section'>
-              <div className='location-how2-section-text1'>자가용</div>
+              <div className='location-how2-section-text1'>{t('byCar')}</div>
               <div className='location-how2-section-text2'>
-                네비게이션 이용 시 “이라운지 서울대점”을 입력하세요. (주차 2시간 무료)
+                {t('carText')}
               </div>
             </div>
             <div className='congratulatory-section'>
-              <div className='congratulatory-section-text'>마음 전하실 곳</div>
-                <div 
-                  className='congratulatory-section-btn' 
-                  onClick={() => accountClick(groomAccountData)}>신랑측 계좌번호</div>
-                <div 
+              <div className='congratulatory-section-text'>{t('congratulate')}</div>
+                <div
                   className='congratulatory-section-btn'
-                  onClick={() => accountClick(brideAccountData)}>신부측 계좌번호</div>
+                  onClick={() => accountClick(groomAccountData)}>{t('groomAccount')}</div>
+                <div
+                  className='congratulatory-section-btn'
+                  onClick={() => accountClick(brideAccountData)}>{t('brideAccount')}</div>
             </div>
             {clickedAccountData && <AccountModal 
               clickedAccountData={clickedAccountData}


### PR DESCRIPTION
## Summary
- create i18n context with translation strings for English and Korean
- wrap the app with `LanguageProvider`
- add a language toggle button
- translate text in `MainPage` and `AccountModal`

## Testing
- `npm test -- -w 1 --ci` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859531af7fc83278a28bdd45f8e6798