### PR TITLE
fix: correct bride account owner name

### DIFF
--- a/src/assets/bride_account_number_data.json
+++ b/src/assets/bride_account_number_data.json
@@ -3,7 +3,7 @@
         {
             "title" : "혼주 계좌",
             "bank_name" : "국민은행",
-            "account_owner" : "고형근",
+            "account_owner" : "고형균",
             "account_number" : "497801-01-090481"
         },
         {


### PR DESCRIPTION
## Summary
- correct account owner name in bride account data

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899f3e6d21c832786bbc24a37fe842c